### PR TITLE
fix ff-merge

### DIFF
--- a/.github/workflows/ff-merge.yaml
+++ b/.github/workflows/ff-merge.yaml
@@ -27,11 +27,13 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ inputs.base_ref }}
+          persist-credentials: false
       - name: fast forward merge
         env:
           GITHUB_TOKEN: ${{ secrets.gh_pa_token_permissive }}
         run: |
           set +e
+          git remote set-url origin 'https://x-access-token:${{ secrets.gh_pa_token_permissive }}@github.com/${{ github.repository }}'
           echo "git fetch origin ${{ inputs.head_ref }}" >tempoutfile
           git fetch origin ${{ inputs.head_ref }} >>tempoutfile 2>&1
           fetch_rc=$?


### PR DESCRIPTION
Okey, some friendly notes first:
- `token` setting that is mentioned here does not work: https://github.com/actions/checkout#usage
- by default, it uses the default GITHUB_TOKEN and caches it in local git config
- if token is set to `${{ secrets.gh_pa_token_permissive }}` it crashes because username is not set. `token` only changes the token not the username. They must have implemented this functionality like a buch of idiots.
- the config file takes precedence over env vars. So setting `GITHUB_TOKEN: ${{ secrets.gh_pa_token_permissive }}` also does not work. This is also backwards, env should always take precedence over files.

Conclusions:
- thank god we can use `persist-credentials: false` to not write the git config because of `config` behavior. Without this option we'd have to fall back to checkout v1.
- we can hack the remote url to pick up credentials from secrets.
- The solution works and has been tested in https://github.com/puro-earth/foobar/actions

You can see that now ff-merge from `main` to `prod` creates a prod push event (and triggers prod).
![Screenshot 2021-11-26 at 11 55 08](https://user-images.githubusercontent.com/6807917/143563247-f3f0dc97-eefc-411f-af7c-4ee5aa6e0a30.png)

