### PR TITLE
feat(azure): add pulumi deployment workflow

### DIFF
--- a/.github/workflows/pulumi-deploy-azure.yaml
+++ b/.github/workflows/pulumi-deploy-azure.yaml
@@ -1,0 +1,76 @@
+name: pulumi deploy
+on:
+  workflow_call:
+    inputs:
+      stack:
+        required: true
+        type: string
+      work-dir:
+        required: false
+        type: string
+        default: "./"
+      skip_smoke_tests:
+        type: boolean
+        default: false
+    secrets:
+      azure_client_id:
+        required: true
+      azure_client_secret:
+        required: true
+      pulumi_access_token:
+        required: true
+      gh_packages_token:
+        required: true
+
+jobs:
+  deploy:
+    name: pulumi deploy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          cache: "yarn"
+      
+      - name: Authenticate to GitHub Packages
+        run: echo "//npm.pkg.github.com/:_authToken=${GH_PACKAGES_TOKEN}" >> ~/.npmrc
+        env:
+          GH_PACKAGES_TOKEN: ${{ secrets.gh_packages_token }}
+
+      - name: Install Yarn dependencies
+        working-directory: ${{ inputs.work-dir }}
+        run: yarn install --frozen-lockfile
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets.azure_credentials }}
+
+      - uses: pulumi/actions@v3
+        name: pulumi preview
+        with:
+          command: preview
+          stack-name: puroearth/${{ inputs.stack }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          work-dir: ${{ inputs.work-dir }}
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.pulumi_access_token }}
+          ARM_CLIENT_ID: ${{ secrets.azure_client_id }}
+          ARM_CLIENT_SECRET: ${{ secrets.azure_client_secret }}
+
+      - uses: pulumi/actions@v3
+        name: pulumi up
+        with:
+          command: up
+          stack-name: puroearth/${{ inputs.stack }}
+          work-dir: ${{ inputs.work-dir }}
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.pulumi_access_token }}
+          ARM_CLIENT_ID: ${{ secrets.azure_client_id }}
+          ARM_CLIENT_SECRET: ${{ secrets.azure_client_secret }}
+          
+      - name: Run smoke-tests
+        if: ${{ !inputs.skip_smoke_tests }}
+        run: yarn smoke-test

--- a/.github/workflows/pulumi-deploy-azure.yaml
+++ b/.github/workflows/pulumi-deploy-azure.yaml
@@ -44,10 +44,6 @@ jobs:
         working-directory: ${{ inputs.work-dir }}
         run: yarn install --frozen-lockfile
 
-      - uses: azure/login@v1
-        with:
-          creds: ${{ secrets.azure_credentials }}
-
       - uses: pulumi/actions@v3
         name: pulumi preview
         with:
@@ -70,7 +66,7 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.pulumi_access_token }}
           ARM_CLIENT_ID: ${{ secrets.azure_client_id }}
           ARM_CLIENT_SECRET: ${{ secrets.azure_client_secret }}
-          
+
       - name: Run smoke-tests
         if: ${{ !inputs.skip_smoke_tests }}
         run: yarn smoke-test


### PR DESCRIPTION
When using service principals to authenticate, Pulumi requires the environment variables `ARM_CLIENT_ID` and `ARM_CLIENT_SECRET` to be set, rather than authenticating via `az login`. For this reason I have added two secrets to the workflow and removed the `az login` step.