### PR TITLE
fix(gh): Add kubelogin in deploy and preview workflows PEAP-554

### DIFF
--- a/.github/workflows/pulumi-deploy-azure.yaml
+++ b/.github/workflows/pulumi-deploy-azure.yaml
@@ -56,6 +56,10 @@ jobs:
         with:
           creds: ${{ secrets.azure_credentials }}
 
+      - uses: azure/use-kubelogin@v1
+        with:
+          kubelogin-version: 'v0.0.29'
+
       - uses: pulumi/actions@v4
         name: pulumi refresh
         with:
@@ -68,6 +72,8 @@ jobs:
           # Required by Pulumi to access Azure resources
           ARM_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
 
       - uses: pulumi/actions@v4
@@ -84,6 +90,8 @@ jobs:
           # Required by Pulumi to access Azure resources
           ARM_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
       
       - uses: pulumi/actions@v4
@@ -99,6 +107,8 @@ jobs:
           # Required by Pulumi to access Azure resources
           ARM_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
 
       - uses: pulumi/actions@v4
@@ -114,6 +124,8 @@ jobs:
           # Required by Pulumi to access Azure resources
           ARM_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
 
       - name: Run smoke-tests

--- a/.github/workflows/pulumi-preview-azure.yaml
+++ b/.github/workflows/pulumi-preview-azure.yaml
@@ -43,6 +43,10 @@ jobs:
         with:
           creds: ${{ secrets.azure_credentials }}
 
+      - uses: azure/use-kubelogin@v1
+        with:
+          kubelogin-version: 'v0.0.29'
+
       - uses: pulumi/actions@v4
         continue-on-error: true
         id: preview-attempt-1
@@ -58,6 +62,8 @@ jobs:
           # Required by Pulumi to access Azure resources
           ARM_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
       
       - uses: pulumi/actions@v4
@@ -73,4 +79,6 @@ jobs:
           # Required by Pulumi to access Azure resources
           ARM_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
+          AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"


### PR DESCRIPTION
Adds the kubelogin tool in the deploy and preview workflows for AKS AD authentication to work. If the AD integration is enabled for the AKS cluster, the kubeconfig includes a [exec config](https://kubernetes.io/docs/reference/config-api/kubeconfig.v1/#ExecConfig) which tells kubectl to use an external command (kubelogin in this case) to do the login. Adding the kubelogin and the envs should not have an effect on normal Kubernetes logins, because no exec options are given in that scenario.

The preview was tested in https://github.com/puro-earth/azure-api-services-infra/pull/188/files . Also similar changes did work on the pr-preview workflow in the api-services repo, which are applied to the `pulumi up` workflow.

[PEAP-554](https://puroearth.atlassian.net/browse/PEAP-554?search_id=1fb0e562-2424-4aaf-abf8-b141095ad05e)

[PEAP-554]: https://puroearth.atlassian.net/browse/PEAP-554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ