### PR TITLE
fix: Force spn login method through envs PEAP-554

### DIFF
--- a/.github/workflows/pulumi-deploy-azure.yaml
+++ b/.github/workflows/pulumi-deploy-azure.yaml
@@ -74,6 +74,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_LOGIN_METHOD: "spn"
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
 
       - uses: pulumi/actions@v4
@@ -92,6 +93,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_LOGIN_METHOD: "spn"
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
       
       - uses: pulumi/actions@v4
@@ -109,6 +111,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_LOGIN_METHOD: "spn"
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
 
       - uses: pulumi/actions@v4
@@ -126,6 +129,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_LOGIN_METHOD: "spn"
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
 
       - name: Run smoke-tests

--- a/.github/workflows/pulumi-preview-azure.yaml
+++ b/.github/workflows/pulumi-preview-azure.yaml
@@ -64,6 +64,7 @@ jobs:
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_LOGIN_METHOD: "spn"
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"
       
       - uses: pulumi/actions@v4
@@ -81,4 +82,5 @@ jobs:
           ARM_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
           AAD_SERVICE_PRINCIPAL_CLIENT_ID: ${{ fromJSON(secrets.azure_credentials).clientId }}
           AAD_SERVICE_PRINCIPAL_CLIENT_SECRET: ${{ fromJSON(secrets.azure_credentials).clientSecret }}
+          AAD_LOGIN_METHOD: "spn"
           AZURE_KEYVAULT_AUTH_VIA_CLI: "true"


### PR DESCRIPTION
### Changes
Forces the service principal login method for any kubelogin get-token calls. Should fix the refresh issues in azure-api-services-infra Github Actions.

PEAP-554